### PR TITLE
Add a progressMonitor in GitCommand and Merger

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/GitCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/GitCommand.java
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.internal.JGitText;
+import org.eclipse.jgit.lib.NullProgressMonitor;
+import org.eclipse.jgit.lib.ProgressMonitor;
 import org.eclipse.jgit.lib.Repository;
 
 /**
@@ -74,6 +76,9 @@ public abstract class GitCommand<T> implements Callable<T> {
 	 */
 	private AtomicBoolean callable = new AtomicBoolean(true);
 
+	/** A progress monitor. */
+	protected ProgressMonitor monitor;
+
 	/**
 	 * Creates a new command which interacts with a single repository
 	 *
@@ -102,6 +107,24 @@ public abstract class GitCommand<T> implements Callable<T> {
 	 */
 	protected void setCallable(boolean callable) {
 		this.callable.set(callable);
+	}
+
+	/**
+	 * The progress monitor associated with the diff operation. By default, this
+	 * is set to <code>NullProgressMonitor</code>
+	 *
+	 * @see NullProgressMonitor
+	 *
+	 * @param monitor
+	 *            A progress monitor
+	 * @return this instance
+	 */
+	public GitCommand<T> setProgressMonitor(ProgressMonitor monitor) {
+		if (monitor == null) {
+			monitor = NullProgressMonitor.INSTANCE;
+		}
+		this.monitor = monitor;
+		return this;
 	}
 
 	/**

--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/MergeCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/MergeCommand.java
@@ -339,13 +339,13 @@ public class MergeCommand extends GitCommand<MergeResult> {
 					resolveMerger.setCommitNames(new String[] {
 							"BASE", "HEAD", ref.getName() }); //$NON-NLS-1$ //$NON-NLS-2$
 					resolveMerger.setWorkingTreeIterator(new FileTreeIterator(repo));
-					noProblems = merger.merge(headCommit, srcCommit);
+					noProblems = merger.merge(monitor, headCommit, srcCommit);
 					lowLevelResults = resolveMerger
 							.getMergeResults();
 					failingPaths = resolveMerger.getFailingPaths();
 					unmergedPaths = resolveMerger.getUnmergedPaths();
 				} else
-					noProblems = merger.merge(headCommit, srcCommit);
+					noProblems = merger.merge(monitor, headCommit, srcCommit);
 				refLogMessage.append(": Merge made by "); //$NON-NLS-1$
 				if (!revWalk.isMergedInto(headCommit, srcCommit))
 					refLogMessage.append(mergeStrategy.getName());


### PR DESCRIPTION
This new attribute allow to give a progressMonitor to custom mergers

Signed-off-by: mcartaud mathieu.cartaud@obeo.com
